### PR TITLE
Fixed Video Playback issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@ techniques. </p>
 			<!-- video-content-bg start -->
 			<div class="video-content-bg" style="background-image:url(assets/images/backgrounds/IRIS_01.jpg)">
 				<div class="bg-overlay"></div>
-				<a href="https://www.youtube.com/watch?v=zxnMpTqxG3M&feature=youtu.be&ab_channel=IrisRover" class="video-play-button popup-youtube pointer-large">
+				<a href="https://www.youtube.com/watch?v=zxnMpTqxG3M" class="video-play-button popup-youtube pointer-large">
 					<span></span>
 				</a>
 			</div><!-- video-content-bg end -->


### PR DESCRIPTION
Code was fine. The link referenced was https://www.youtube.com/watch?v=zxnMpTqxG3M&feature=youtu.be&ab_channel=IrisRover but magnific popup only, by default, supports youtube links with the format https://www.youtube.com/watch?v={VIDEO_ID} so I just inspect elemented the button and changed the target tohttps://www.youtube.com/watch?v=zxnMpTqxG3M and it worked. This change reflects that.

Relevant magnific popup documentation:
https://dimsemenov.com/plugins/magnific-popup/documentation.html#iframe-type

Interestingly, when I opened Syntra Small (vanilla text editor so it wouldn't lint the code) to edit this it flagged this line and this line only as having the error ("Named Entity Expected. Got None.") No idea what this means but it was resolved by editting this line.